### PR TITLE
Mypy

### DIFF
--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -31,5 +31,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: pip install .[test]
+      - name: MyPy checks 
+        run: |
+          pip install mypy
+          mypy --ignore-missing-imports --install-types --non-interactive sphinx_favicon
       - name: Run Tests for ${{ matrix.python-version }}
         run: pytest --color=yes tests

--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
           - os: macos-latest

--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -30,13 +30,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          python -VV
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install -r dev-requirements.txt
-      - name: Install Package
-        run: |
-          python -m pip install .
+        run: pip install .[test]
       - name: Run Tests for ${{ matrix.python-version }}
-        run: |
-          python -m pytest -vv
+        run: pytest --color=yes tests

--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8" 
+          python-version: '3.8' 
       - uses: pre-commit/action@v3.0.0
 
   test:
@@ -23,6 +23,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
+        include:
+          - os: macos-latest
+            python-version: '3.9'
+          - os: windows-latest
+            python-version: '3.9'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,129 @@
-.vscode/*
-.env*
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
-dist/*
-*egg-info/*
-*.pyc
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
 build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@ def mypy(session):
     """Run the mypy evaluation of the lib."""
     session.install(".")
     session.install("mypy")
-    test_files = session.posargs or ["sphinx-favicon"]
+    test_files = session.posargs or ["sphinx_favicon"]
     session.run(
         "mypy",
         "--ignore-missing-imports",

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,6 +9,7 @@ def test(session):
     session.install(".[test]")
     session.run("pytest", "--color=yes", "tests")
 
+
 @nox.session(name="mypy", reuse_venv=True)
 def mypy(session):
     """Run the mypy evaluation of the lib."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,24 @@
+"""Test process to run in isolated environments."""
+
+import nox
+
+
+@nox.session(python=["3.7", "3.8", "3.9"], reuse_venv=True)
+def test(session):
+    """Apply the tests on the lib."""
+    session.install(".[test]")
+    session.run("pytest", "--color=yes", "tests")
+
+@nox.session(name="mypy", reuse_venv=True)
+def mypy(session):
+    """Run the mypy evaluation of the lib."""
+    session.install(".")
+    session.install("mypy")
+    test_files = session.posargs or ["sphinx-favicon"]
+    session.run(
+        "mypy",
+        "--ignore-missing-imports",
+        "--install-types",
+        "--non-interactive",
+        *test_files,
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,10 @@ packages = sphinx-favicon
 install_requires =
     sphinx >= 3.4
 python_requires = >=3.6
+
+[options.extras_require]
+test = 
+    pytest
+    beautifulsoup4
+dev = 
+    nox

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,3 +42,7 @@ test =
     beautifulsoup4
 dev = 
     nox
+doc = 
+    sphinx
+    pydata-sphinx-theme
+


### PR DESCRIPTION
Fix #4 

- create `extra_require` for "doc", "test" and "dev" build avoiding the use of `requirement-dev.txt` (should be removed in my next doc PR)
- use [nox](https://nox.thea.codes/en/stable/) for isolated build of "test", "doc" and "mypy" 
- only set `mypy` test in `nox` and not in `pre-commit` as there are multiple issue with the pre-commit cache environment (https://github.com/pre-commit/mirrors-mypy/issues/3)
- add mypy test in the github action 
- reduce the number of test (only test macos and windows on py3.9