### PR TITLE
authorize any parameter in the favicon dict

### DIFF
--- a/sphinx_favicon/__init__.py
+++ b/sphinx_favicon/__init__.py
@@ -51,27 +51,31 @@ def generate_meta(favicon: Dict[str, str]) -> str:
     Returns:
         Favicon link or meta tag
     """
-    rel = favicon.get("rel", "icon")
-    href = favicon["href"]
-    meta = f'    <link rel="{rel}" href="{href}"'
+    # get the tag of the output
+    tag = "link"
 
-    # Read "sizes" from config. Omit sizes if not provided.
-    sizes = favicon.get("sizes")
-    if sizes:
-        meta += f' sizes="{sizes}"'
+    # prepare all the tag parameters and leave them in the favicon dict
 
-    # Set MIME type. Detect MIME type if not provided. Omit "type=" if not detectable
-    favicon_type = favicon.get("type")
-    favicon_file_ending = href.split(".")[-1]
-    if favicon_type:
-        meta += f' type="{favicon_type}"'
-    elif favicon_file_ending in SUPPORTED_MIME_TYPES.keys():
-        favicon_type = SUPPORTED_MIME_TYPES[favicon_file_ending]
-        meta += f' type="{favicon_type}"'
+    # to raise an error if not set
+    favicon["href"]
 
-    meta += ">"
+    # default to "icon"
+    favicon.setdefault("rel", "icon")
 
-    return meta
+    # set the type. if type is not set try to guess it from the file extention
+    type_ = favicon.get("type")
+    if not type_:
+        extention = favicon["href"].split(".")[-1]
+        if extention in SUPPORTED_MIME_TYPES.keys():
+            type_ = SUPPORTED_MIME_TYPES[extention]
+    if type_ is not None:
+        favicon["type"] = type_
+
+    # build the html element
+    parameters = [f"{k}={v}" for k, v in favicon.items()]
+    html_element = f"    <{tag} {' '.join(parameters)}>"
+    print(html_element)
+    return html_element
 
 
 def _static_to_href(pathto: Callable, favicon: Dict[str, str]) -> Dict[str, str]:

--- a/sphinx_favicon/__init__.py
+++ b/sphinx_favicon/__init__.py
@@ -49,19 +49,19 @@ def generate_meta(favicon: Dict[str, str]) -> str:
         favicon: Favicon data
 
     Returns:
-        Favicon meta tag
+        Favicon link or meta tag
     """
     rel = favicon.get("rel", "icon")
     href = favicon["href"]
     meta = f'    <link rel="{rel}" href="{href}"'
 
     # Read "sizes" from config. Omit sizes if not provided.
-    sizes = favicon.get("sizes", None)
+    sizes = favicon.get("sizes")
     if sizes:
         meta += f' sizes="{sizes}"'
 
     # Set MIME type. Detect MIME type if not provided. Omit "type=" if not detectable
-    favicon_type = favicon.get("type", None)
+    favicon_type = favicon.get("type")
     favicon_file_ending = href.split(".")[-1]
     if favicon_type:
         meta += f' type="{favicon_type}"'

--- a/sphinx_favicon/__init__.py
+++ b/sphinx_favicon/__init__.py
@@ -72,7 +72,7 @@ def generate_meta(favicon: Dict[str, str]) -> str:
         favicon["type"] = type_
 
     # build the html element
-    parameters = [f"{k}={v}" for k, v in favicon.items()]
+    parameters = [f'{k}="{v}"' for k, v in favicon.items()]
     html_element = f"    <{tag} {' '.join(parameters)}>"
     print(html_element)
     return html_element


### PR DESCRIPTION
Fix #22 

Refactored the `generate_meta` function: 
- set the tag name to link by default (prepare the ground for the meta tags from msapp)
- check if href is set implicitely 
- leave all the tag in the favicon dict (keep checks for the type)
- aggregate them only at the end 

By doing so, if I set the follwing:
```python 
  {
        "rel": "mask-icon",
        "static-file": "favicon/safari-pinned-tab.svg",
        "color": "#459db9",
 }
```

will be rendered as:
```html
<link ref="mask-icon" href="_static/favicon/safari-pinned-tab.svg" color="#459db9" type="image/svg+xml">
```