### PR TITLE
Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Auto detect text files and perform LF normalization
-* text=auto


### PR DESCRIPTION
I'm not sure it's very useful and it can be dangerous as explained here: https://stackoverflow.com/a/38017715/6734243 end-of-line will be managed in the linter anyway