### PR TITLE
edit announcement link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,7 +47,7 @@ html_theme_options = {
     ],
     "logo": {"text": project},
     "use_edit_page_button": True,
-    "announcement": "https://raw.githubusercontent.com/12rambau/sphinx-favicon/doc/docs/source/_static/announcment.html",
+    "announcement": "https://raw.githubusercontent.com/tcmetzger/sphinx-favicon/main/docs/source/_static/announcment.html",
 }
 
 # -- Option for favicons -------------------------------------------------------


### PR DESCRIPTION
The branch I used to create the announcement has been merged and deleted. The link now points to the file from "main" so it won't need to be changed anymore.