### PR TITLE
fixed `documentation` and `contribution` broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Based on this configuration, Sphinx will include the following favicon informati
 ```
 
 For more details and more advanced usage, please see the
-[documentation](https://sphinx-favicon.readthedocs.io/en/stable).
+[documentation](https://sphinx-favicon.readthedocs.io/en/latest/).
 
 ## Contribution
 
 Contributions of any kind are welcome. Please see the
-[contribution](https://sphinx-favicon.readthedocs.io/en/stable#Contribute) section of
+[contribution](https://sphinx-favicon.readthedocs.io/en/latest/contribute.html) section of
 our documentation for more information.


### PR DESCRIPTION
changed the links in [Readme.md](https://github.com/tcmetzger/sphinx-favicon#readme) of `documentation` and `contribute`
Fixed issue #39 