### PR TITLE
fix: remove download url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ content-type = "text/markdown"
 
 [project.urls]
 Homepage = "https://github.com/tcmetzger/sphinx-favicon"
-Download = "https://github.com/tcmetzger/sphinx-favicon/archive/v${metadata:version}.tar.gz"
 
 [project.optional-dependencies]
 dev = ["pre-commit", "nox"]


### PR DESCRIPTION
The way links were written in setup.py cannot work  annymore. I decided to remove it entirely as the tarball is anyway accecible in the files tab of all pypi projects: https://pypi.org/project/sphinx-favicon/#files

setting it in the metadata is just a duplication.

Fix #38 