### PR TITLE
fix: make the panels compatible with dark theme

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,29 +28,26 @@ This documentation contains three sections:
    .. grid-item-card::
       :link: quickstart
       :link-type: ref
-      :class-header: card-header-gray
 
       Quickstart
       ^^^
-      ➡ Installation and basic usage
+      :fas:`square-caret-right;sd-text-primary` Installation and basic usage
 
    .. grid-item-card::
       :link: configuration
       :link-type: ref
-      :class-header: card-header-gray
 
       Configuration
       ^^^
-      ➡ Detailed information about all configuration options and examples
+      :fas:`square-caret-right;sd-text-primary` Detailed information about all configuration options and examples
 
    .. grid-item-card::
       :link: contribute
       :link-type: ref
-      :class-header: card-header-gray
 
       Contribute
       ^^^
-      ➡ Help improve Sphinx Favicon
+      :fas:`square-caret-right;sd-text-primary` Help improve Sphinx Favicon
 
 
 .. toctree::


### PR DESCRIPTION
Fix #48 
I realized we were using the `sphinx_design` lib already, it's just the panel color header you selected that has 0 contrast in dark theme. 

- I changed the header color to "none" so it works fine with bothe themes
- I replaced the emoji with icons so that it works even on computer that don't have the emoji font (as we embed the fontawesome icons in the website)