### PR TITLE
Modernize tests and update dependencies for Python 3.10–3.13

### DIFF
--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -1,4 +1,4 @@
-name: Python lint and test
+name: CI
 
 on:
   push:
@@ -7,38 +7,48 @@ on:
     branches: [ main ]
 
 jobs:
-
-  format:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
-      - uses: pre-commit/action@v3.0.0
+          python-version: '3.12'
+      - uses: pre-commit/action@v3.0.1
 
-  test:
-    runs-on: ${{ matrix.os }}
+  tests:
+    name: Python ${{ matrix.python }} | Sphinx ${{ matrix.sphinx }}
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
-          - os: macos-latest
-            python-version: '3.9'
-          - os: windows-latest
-            python-version: '3.9'
+          - python: '3.10'
+            sphinx: '8.1.*'
+          - python: '3.11'
+            sphinx: '8.1.*'
+          - python: '3.12'
+            sphinx: '9.1.*'
+          - python: '3.13'
+            sphinx: '9.1.*'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: pip install .[test]
-      - name: MyPy checks
+          python-version: ${{ matrix.python }}
+      - name: Install tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox
+      - name: Install Sphinx and test deps
+        run: |
+          pip install "sphinx==${{ matrix.sphinx }}"
+          pip install -e .[test]
+      - name: Type check (mypy)
         run: |
           pip install mypy
           mypy --ignore-missing-imports --install-types --non-interactive sphinx_favicon
-      - name: Run Tests for ${{ matrix.python-version }}
-        run: pytest --color=yes --cov --cov-report=xml tests
+      - name: Run tests
+        run: |
+          nox -s test -- --color=yes --cov --cov-report=xml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+# 2026-02-04, Release 1.1.0
+
+Modernize package for Python 3.10–3.13 and Sphinx 8/9.
+
+## What's Changed
+* Add official support for Python 3.10, 3.11, 3.12, 3.13; drop 3.7–3.9 classifiers
+* Bump Sphinx dependency to >=8.1,<10 to ensure Python 3.13 compatibility (fixes imghdr removal)
+* Update tests to use `root_doc` instead of deprecated `master_doc`
+* Refresh CI: test matrix over Python 3.10–3.13 and Sphinx 8.1 / 9.1
+* Update documentation extras to build with modern Sphinx
+
+**Full Changelog**: https://github.com/tcmetzger/sphinx-favicon/compare/v1.0.1...v1.1.0
+
 # 2023-03-02, Release 1.0.1
 
 This is a bugfix for Release 1.0 and contains only one change.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-# 2026-02-04, Release 1.1.0
+# 2026-02-12, Release 1.1.0
 
 Modernize package for Python 3.10–3.13 and Sphinx 8/9.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/tcmetzger/sphinx-favicon/basic-ci.yml?logo=github&logoColor=white)](https://github.com/tcmetzger/sphinx-favicon/actions/workflows/basic-ci.yml)
 [![Read the Docs (version)](https://img.shields.io/readthedocs/sphinx-favicon/latest?logo=readthedocs&logoColor=white)](https://readthedocs.org/projects/sphinx-favicon/)
 
-> **Note: Updating from Version 0.2 to Version 1.0**
+> **Note: Updating from Version 0.2 to Version 1.x and beyond**
 >
 > Between v0.2 and v1.0, the module name of the extension changed to better conform with Python standards. Please update the name used in the extension list of your `conf.py` from `sphinx-favicon` to `sphinx_favicon`!
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,17 +2,19 @@
 
 # -- imports and read config ---------------------------------------------------
 import datetime as dt
+from importlib import metadata
 
-import pkg_resources
-
-version = pkg_resources.require("sphinx-favicon")[0].version
+try:
+    release_version = metadata.version("sphinx-favicon")
+except metadata.PackageNotFoundError:
+    release_version = "unknown-dev"
 year = dt.datetime.now().year
 
 # -- Project information -------------------------------------------------------
 project = "Sphinx Favicon"
 copyright = f"{year}, Timo Metzger"
 author = "Timo Metzger"
-release = version
+release = release_version
 
 # -- General configuration -----------------------------------------------------
 extensions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 40.9.0","wheel"]
+requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sphinx-favicon"
-version = "1.0.1"
+version = "1.1.0"
 description = "Sphinx Extension adding support for custom favicons"
 keywords = ["sphinx", "extension", "favicon", "meta html"]
 classifiers = [
@@ -16,10 +16,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python",
     "Topic :: Utilities",
     "Topic :: Documentation",
@@ -27,8 +27,15 @@ classifiers = [
     "Topic :: Software Development :: Documentation",
     "Topic :: Text Processing",
 ]
-requires-python = ">=3.7"
-dependencies = ["sphinx>=3.4"]
+requires-python = ">=3.10"
+dependencies = [
+    # Sphinx >=8 removes deprecated internals and is compatible with Python 3.13
+    # Also compatible with Sphinx 9 (Python >=3.12). Keep <10 for safety.
+    "sphinx>=8.1,<10",
+    # Direct runtime deps used by the extension
+    "imagesize>=1.3",
+    "requests>=2.30",
+]
 
 [[project.authors]]
 name = "Timo Cornelius Metzger"
@@ -47,7 +54,12 @@ Homepage = "https://github.com/tcmetzger/sphinx-favicon"
 [project.optional-dependencies]
 dev = ["pre-commit", "nox"]
 test = ["pytest", "beautifulsoup4", "pytest-cov"]
-doc = ["sphinx<6", "pydata-sphinx-theme", "sphinx-copybutton", "sphinx-design"]
+doc = [
+    "sphinx>=8.1,<10",
+    "pydata-sphinx-theme",
+    "sphinx-copybutton",
+    "sphinx-design",
+]
 
 [tool.setuptools]
 license-files = ["LICENSE"]

--- a/sphinx_favicon/__init__.py
+++ b/sphinx_favicon/__init__.py
@@ -8,9 +8,9 @@ The sphinx-favicon extension gives you more flexibility than the standard favico
 """
 
 from io import BytesIO
-from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union, Sequence, cast
 from os import PathLike
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union, cast
 from urllib.parse import urlparse
 
 import docutils.nodes as nodes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,47 @@
-"""Configuration fixtures of the tests."""
+"""Configuration fixtures of the tests (compatible with modern Sphinx)."""
+
+from pathlib import Path
 
 import pytest
 from bs4 import BeautifulSoup
-from sphinx.testing.path import path
+import re
 
 pytest_plugins = "sphinx.testing.fixtures"
 
 
 @pytest.fixture(scope="session")
-def rootdir():
-    """The root directory."""
-    return path(__file__).parent.abspath() / "roots"
+def rootdir() -> Path:
+    """The root directory for Sphinx test roots."""
+    return Path(__file__).resolve().parent / "roots"
+
+
+@pytest.fixture(autouse=True)
+def _stub_network_for_images(monkeypatch):
+    """Stub sphinx_favicon.requests.get to avoid network access during tests.
+
+    Returns minimal GIF bytes with the requested dimensions parsed from the URL
+    (e.g., "...16x16..." -> 16x16). Defaults to 16x16 if not found.
+    """
+
+    def _gif_bytes(w: int, h: int) -> bytes:
+        # Minimal GIF header: "GIF89a" + width + height (little-endian) + 3 padding bytes
+        return b"GIF89a" + int(w).to_bytes(2, "little") + int(h).to_bytes(2, "little") + b"\x00\x00\x00"
+
+    def fake_get(url: str, *args, **kwargs):
+        m = re.search(r"(\d+)x(\d+)", url)
+        if m:
+            w, h = int(m.group(1)), int(m.group(2))
+        else:
+            # Sensible default for URLs without size hint; tests don't assert these sizes
+            w, h = 16, 16
+
+        class _Resp:
+            status_code = 200
+            content = _gif_bytes(w, h)
+
+        return _Resp()
+
+    monkeypatch.setattr("sphinx_favicon.requests.get", fake_get)
 
 
 @pytest.fixture()
@@ -22,7 +53,7 @@ def content(app):
 
 def _link_tags(content, page):
     """Link tags in a page content."""
-    c = (content.outdir / page).read_text()
+    c = (Path(content.outdir) / page).read_text()
     return BeautifulSoup(c, "html.parser").find_all("link")
 
 
@@ -37,7 +68,7 @@ def _favicon_tags(content, page="index.html"):
 
 def _meta_tags(content, page):
     """Link tags in a page content."""
-    c = (content.outdir / page).read_text()
+    c = (Path(content.outdir) / page).read_text()
     return BeautifulSoup(c, "html.parser").find_all("meta")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 """Configuration fixtures of the tests (compatible with modern Sphinx)."""
 
+import re
 from pathlib import Path
 
 import pytest
 from bs4 import BeautifulSoup
-import re
 
 pytest_plugins = "sphinx.testing.fixtures"
 
@@ -25,7 +25,12 @@ def _stub_network_for_images(monkeypatch):
 
     def _gif_bytes(w: int, h: int) -> bytes:
         # Minimal GIF header: "GIF89a" + width + height (little-endian) + 3 padding bytes
-        return b"GIF89a" + int(w).to_bytes(2, "little") + int(h).to_bytes(2, "little") + b"\x00\x00\x00"
+        return (
+            b"GIF89a"
+            + int(w).to_bytes(2, "little")
+            + int(h).to_bytes(2, "little")
+            + b"\x00\x00\x00"
+        )
 
     def fake_get(url: str, *args, **kwargs):
         m = re.search(r"(\d+)x(\d+)", url)

--- a/tests/roots/test-href_and_static/conf.py
+++ b/tests/roots/test-href_and_static/conf.py
@@ -1,6 +1,6 @@
 extensions = ["sphinx_favicon"]
 
-master_doc = "index"
+root_doc = "index"
 exclude_patterns = ["_build"]
 
 html_theme = "basic"

--- a/tests/roots/test-list_of_three_dicts/conf.py
+++ b/tests/roots/test-list_of_three_dicts/conf.py
@@ -1,6 +1,6 @@
 extensions = ["sphinx_favicon"]
 
-master_doc = "index"
+root_doc = "index"
 exclude_patterns = ["_build"]
 
 html_theme = "basic"

--- a/tests/roots/test-list_of_three_icons_automated_values/conf.py
+++ b/tests/roots/test-list_of_three_icons_automated_values/conf.py
@@ -1,6 +1,6 @@
 extensions = ["sphinx_favicon"]
 
-master_doc = "index"
+root_doc = "index"
 exclude_patterns = ["_build"]
 
 html_theme = "basic"

--- a/tests/roots/test-list_of_urls/conf.py
+++ b/tests/roots/test-list_of_urls/conf.py
@@ -1,6 +1,6 @@
 extensions = ["sphinx_favicon"]
 
-master_doc = "index"
+root_doc = "index"
 exclude_patterns = ["_build"]
 
 html_theme = "basic"

--- a/tests/roots/test-msapp_meta/conf.py
+++ b/tests/roots/test-msapp_meta/conf.py
@@ -1,6 +1,6 @@
 extensions = ["sphinx_favicon"]
 
-master_doc = "index"
+root_doc = "index"
 exclude_patterns = ["_build"]
 
 html_theme = "basic"

--- a/tests/roots/test-single_dict/conf.py
+++ b/tests/roots/test-single_dict/conf.py
@@ -1,6 +1,6 @@
 extensions = ["sphinx_favicon"]
 
-master_doc = "index"
+root_doc = "index"
 exclude_patterns = ["_build"]
 
 html_theme = "basic"

--- a/tests/roots/test-static_files/conf.py
+++ b/tests/roots/test-static_files/conf.py
@@ -1,6 +1,6 @@
 extensions = ["sphinx_favicon"]
 
-master_doc = "index"
+root_doc = "index"
 exclude_patterns = ["_build"]
 
 html_theme = "basic"


### PR DESCRIPTION
Support Python versions 3.10 to 3.13 and Sphinx 8/9. 
Refresh tests to align with modern Sphinx practices.
Update for release 1.1.0

Fixes #55 (and several other issues)